### PR TITLE
Read circleplusmac from stick status response

### DIFF
--- a/plugwise/api.py
+++ b/plugwise/api.py
@@ -52,6 +52,8 @@ class Stick(SerialComChannel):
     """provides interface to the Plugwise Stick"""
 
     def __init__(self, port=0, timeout=DEFAULT_TIMEOUT):
+        self.mac = None
+        self.circleplusmac = None
         self.circles = {} #dictionary {mac, circle} filled by circle init
         self.last_counter = 0
         self.unjoined = set()
@@ -64,6 +66,9 @@ class Stick(SerialComChannel):
         msg = PlugwiseStatusRequest().serialize()
         self.send_msg(msg)
         resp = self.expect_response(PlugwiseStatusResponse)
+        print resp.mac
+        if not resp.circleplusmac is None:
+            self.circleplusmac = "00"+resp.circleplusmac.serialize()
         debug(str(resp))
 
     def reconnect(self):
@@ -309,6 +314,8 @@ class Stick(SerialComChannel):
         #The short reponse occurs when no cirlceplus is connected, and has two byte parameters.
         #The short repsonse is likely not properly handled (exception?)
         resp = self.expect_response(PlugwiseStatusResponse)
+        if not resp.circleplusmac is None:
+            self.circleplusmac = "00"+resp.circleplusmac.serialize()
         return        
         
     def find_circleplus(self):
@@ -326,7 +333,7 @@ class Stick(SerialComChannel):
         return success,circleplusmac
 
     def connect_circleplus(self):
-        req = PlugwiseConnectCirclePlusRequest(self.mac)
+        req = PlugwiseConnectCirclePlusRequest(self.circleplusmac)
         _, seqnr  = self.send_msg(req.serialize())
         resp = self.expect_response(PlugwiseConnectCirclePlusResponse)
         return resp.existing.value, self.allowed.value        

--- a/plugwise/api.py
+++ b/plugwise/api.py
@@ -66,7 +66,6 @@ class Stick(SerialComChannel):
         msg = PlugwiseStatusRequest().serialize()
         self.send_msg(msg)
         resp = self.expect_response(PlugwiseStatusResponse)
-        print resp.mac
         if not resp.circleplusmac is None:
             self.circleplusmac = "00"+resp.circleplusmac.serialize()
         debug(str(resp))

--- a/plugwise/protocol.py
+++ b/plugwise/protocol.py
@@ -495,13 +495,15 @@ class PlugwiseStatusResponse(PlugwiseResponse):
         PlugwiseResponse.__init__(self, seqnr)
         self.unknown = Int(0, length=2)
         self.network_is_online = Int(0, length=2)
-        self.network_id = Int(0, length=16)
+        self.unknown = Int(0, length=2)
+        self.circleplusmac = String(None, length=14)
         self.network_id_short = Int(0, length=4)
         self.unknown = Int(0, length=2)
         self.params += [
             self.unknown,
             self.network_is_online,
-            self.network_id,
+            self.unknown,
+            self.circleplusmac,
             self.network_id_short,
             self.unknown,
         ]


### PR DESCRIPTION
The circleplusmac is embedded in the Stick status response.
It can be read and used further detecting the network.

One caveat, I don't know the contents of the response when there is no circleplus associated to the Stick.

I am planning to use the api separately from the web interface. As such I don't know the overal impact of this, but I don't believe it breaks anything.