### PR TITLE
Update HTTPWebSocketsHandler.py

### DIFF
--- a/swutil/HTTPWebSocketsHandler.py
+++ b/swutil/HTTPWebSocketsHandler.py
@@ -31,6 +31,7 @@ class HTTPWebSocketsHandler(SimpleHTTPRequestHandler):
     _opcode_close = 0x8
     _opcode_ping = 0x9
     _opcode_pong = 0xa
+    protocol_version = 'HTTP/1.1'
 
     #mutex = threading.Lock()
     


### PR DESCRIPTION
With chrome and on the macbook air with safari the measurements are not showing.
I started to check the developers tool in Safari. When connecting with Plugwise-2-web.py it logs multiple messages like:

WebSocket connection to 'ws://diskstation:8000/socket.ws' failed: Invalid HTTP version string: HTTP/1.0